### PR TITLE
Changed tradeID to string in ExitOrder to correct TakeProfitOrder error

### DIFF
--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/ExitOrder.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/ExitOrder.cs
@@ -8,7 +8,7 @@ namespace OkonkwoOandaV20.TradeLibrary.Order
 	  /// <summary>
 	  /// The ID of the Trade to close when the price threshold is breached.
 	  /// </summary>
-	  public long tradeID { get; set; }
+	  public string tradeID { get; set; }
 
 	  /// <summary>
 	  /// The client ID of the Trade to be closed when the price threshold is


### PR DESCRIPTION
I ran into an issue with the Oanda API rejecting my order request for TakeProfit order based on the tradeID type being a long which resulted in missing quotations around the value for tradeID.  

Please look at the comments on the commit for more information.