### PR TITLE
Fixed test for machines using comma as decimal separator

### DIFF
--- a/OkonkwoOandaV20/OkonkwoOandaV20Tests/Framework/JsonConverters/StringDecimalConverterTests.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20Tests/Framework/JsonConverters/StringDecimalConverterTests.cs
@@ -38,7 +38,7 @@ namespace OkonkwoOandaV20Tests.Framework.JsonConverters
 		 converter.WriteJson(writer, value, serializer);
 
 		 //assert
-		 Assert.IsTrue(stringBuilder.ToString() == $"\"{value}\"");
+		 Assert.IsTrue(stringBuilder.ToString() == System.FormattableString.Invariant($"\"{value}\""));
 	  }
    }
 }


### PR DESCRIPTION
Some cultures e. g. German cultrue use a comma and not a period as decimal separator. Thus 12.5 becomes 12,5 and the test fails. Using the invariant culture avoids the problem here.